### PR TITLE
Add PyDeck dependency and stabilize RFM scoring

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ reportlab
 python-dateutil
 pytz
 openpyxl
+pydeck


### PR DESCRIPTION
## Summary
- add PyDeck to requirements to enable Streamlit map charts
- document PyDeck installation in setup instructions
- guard RFM quantile scoring against small or uniform datasets

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
import pandas as pd
from sqlalchemy import create_engine
from datetime import date
import app
engine = create_engine('sqlite:///:memory:')
# create tables
pd.DataFrame({'order_id':['o1','o2','o3'], 'order_date':pd.to_datetime(['2024-01-01','2024-01-01','2024-01-01']), 'buyer_id':['b1','b2','b3']}).to_sql('orders', engine, index=False)
pd.DataFrame({'id':[1,2,3],'order_id':['o1','o2','o3'],'sku':['s1','s2','s3'],'qty':[1,1,1],'unit_price':[100,100,100],'cogs':[0,0,0],'shipping_alloc':[0,0,0],'fee_alloc':[0,0,0],'ad_cost_alloc':[0,0,0]}).to_sql('order_items', engine, index=False)
app.get_engine=lambda: engine
print(app.rfm_scores(date.today()))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b06cc8e0e48323bfa50409262dd42b